### PR TITLE
Fix Refresh 404 Error

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -2,7 +2,7 @@
   "hosting": {
     "rewrites": [ {
       "source": "**",
-      "destination": "/Home"
+      "destination": "/"
     }],
     "public": "build",
     "ignore": [

--- a/firebase.json
+++ b/firebase.json
@@ -2,7 +2,7 @@
   "hosting": {
     "rewrites": [ {
       "source": "**",
-      "destination": "/"
+      "destination": "/index.html"
     }],
     "public": "build",
     "ignore": [

--- a/firebase.json
+++ b/firebase.json
@@ -1,5 +1,9 @@
 {
   "hosting": {
+    "rewrites": [ {
+      "source": "**",
+      "destination": "/"
+    }],
     "public": "build",
     "ignore": [
       "firebase.json",

--- a/firebase.json
+++ b/firebase.json
@@ -2,7 +2,7 @@
   "hosting": {
     "rewrites": [ {
       "source": "**",
-      "destination": "/"
+      "destination": "/Home"
     }],
     "public": "build",
     "ignore": [


### PR DESCRIPTION
This error was being caused by a client trying to reach a file that doesn't exist within our project. For example if someone went directly to "rowde-books.web.app/Login" it would produce a 404 error. This fix uses 'rewrites' in firebase.json file. (https://firebase.google.com/docs/hosting/full-config#rewrites) 